### PR TITLE
Fix typos

### DIFF
--- a/Chat-Command-Reference.md
+++ b/Chat-Command-Reference.md
@@ -140,7 +140,7 @@ Creates a hollow torus at position 1 with the radius major and minor radii. Work
 ## `//line [<replace_node> [<radius>]]`
 Draw a line from position 1 to position 2, optionally with a given thickness.
 
-The radius can be tought fo as the thickness of the line, and is defined as the distance from a given node to an imaginary line from pos1 to pos2. Defaults to drawing with dirt and a radius of 1.
+The radius can be thought of as the thickness of the line, and is defined as the distance from a given node to an imaginary line from pos1 to pos2. Defaults to drawing with dirt and a radius of 1.
 
 Floating-point values are fully supported for the radius.
 
@@ -198,7 +198,7 @@ The optional `path_depth` parameter defaults to `1` and allows customisation of 
 ```
 
 ## `//bonemeal [<strength> [<chance>]]`
-Requires the [`bonemeal`](https://content.minetest.net/packages/TenPlus1/bonemeal/) ([repo](https://notabug.org/TenPlus1/bonemeal/)) mod (otherwise _WorldEditAdditions_ will not register this command and outut a message to the server log). Alias: `//flora`.
+Requires the [`bonemeal`](https://content.minetest.net/packages/TenPlus1/bonemeal/) ([repo](https://notabug.org/TenPlus1/bonemeal/)) mod (otherwise _WorldEditAdditions_ will not register this command and output a message to the server log). Alias: `//flora`.
 
 Bonemeals all eligible nodes in the current region. An eligible node is one that has an air node directly above it - note that just because a node is eligible doesn't mean to say that something will actually happen when the `bonemeal` mod bonemeals it.
 

--- a/worldeditadditions/utils/node_identification.lua
+++ b/worldeditadditions/utils/node_identification.lua
@@ -55,7 +55,7 @@ end
 -- Nodes with the "sapling" group are considered saplings.
 -- It is recommended that the result of this function be cached.
 -- @param	id		number	The content/node id to check.
--- @return	bool	Whther the given node/content id is a sapxling or not.
+-- @return	bool	Whether the given node/content id is a sapling or not.
 function worldeditadditions.is_sapling(id)
 	local node_name = minetest.get_name_from_content_id(id)
 	return minetest.get_item_group(node_name, "sapling") ~= 0

--- a/worldeditadditions/utils/nodes.lua
+++ b/worldeditadditions/utils/nodes.lua
@@ -1,5 +1,5 @@
 --- Makes an associative table of node_name => weight into a list of node ids.
--- Node names with a heigher weight are repeated more times.
+-- Node names with a higher weight are repeated more times.
 function worldeditadditions.make_weighted(tbl)
 	local result = {}
 	for node_name, weight in pairs(tbl) do

--- a/worldeditadditions/utils/strings.lua
+++ b/worldeditadditions/utils/strings.lua
@@ -273,7 +273,7 @@ end
 --- Formats (usually large) numbers as human-readable strings.
 -- Ported from PHP: https://github.com/sbrl/Pepperminty-Wiki/blob/0a81c940c5803856db250b29f54658476bc81e21/core/05-functions.php#L67
 -- @param	n			number	The number to format.
--- @param	decimals	number	The number fo decimal places to show.
+-- @param	decimals	number	The number of decimal places to show.
 -- @return	string		A formatted string that represents the given input number.
 function worldeditadditions.human_size(n, decimals)
 	sizes = { "", "K", "M", "G", "T", "P", "E", "Y", "Z" }

--- a/worldeditadditions_commands/commands/meta/many.lua
+++ b/worldeditadditions_commands/commands/meta/many.lua
@@ -1,7 +1,7 @@
 --- Executes multiple worldedit commands in sequence.
 -- @module worldeditadditions.multi
 
--- explode(seperator, string)
+-- explode(separator, string)
 -- From http://lua-users.org/wiki/SplitJoin
 local function explode(delim, str)
 	local ll, is_done

--- a/worldeditadditions_commands/commands/meta/multi.lua
+++ b/worldeditadditions_commands/commands/meta/multi.lua
@@ -1,7 +1,7 @@
 --- Executes multiple worldedit commands in sequence.
 -- @module worldeditadditions.multi
 
--- explode(seperator, string)
+-- explode(separator, string)
 -- From http://lua-users.org/wiki/SplitJoin
 local function explode(delim, str)
 	local ll, is_done

--- a/worldeditadditions_farwand/lib/chatcommand.lua
+++ b/worldeditadditions_farwand/lib/chatcommand.lua
@@ -21,7 +21,7 @@ end
 
 minetest.register_chatcommand("/farwand", {
 	params = "skip_liquid (true|false) | maxdist <number>",
-	description = "Configures your worldeditadditions farwand tool on a per-player basis. skip_liquid configures whether liquids will be skipped when raycasting. maxdist configues the maximum distance to raycast looking for a suitable node (default: 1000, but while higher values mean that it will search further, it's not an exact number of nodes that will be searched)",
+	description = "Configures your worldeditadditions farwand tool on a per-player basis. skip_liquid configures whether liquids will be skipped when raycasting. maxdist configures the maximum distance to raycast looking for a suitable node (default: 1000, but while higher values mean that it will search further, it's not an exact number of nodes that will be searched)",
 	privs = { worldedit = true },
 	func = function(name, params_text)
 		if name == nil then return end


### PR DESCRIPTION
As usual, when I like a project, I use [codespell](https://github.com/codespell-project/codespell)﻿ to clean up typos in it.

This PR also trims whitespace at the end of lines commonly left by editors, as I have VS Code configured to do that (I hope you don't mind @sbrl!)
