### PR TITLE
Added //srect and //basename

### DIFF
--- a/worldeditadditions/init.lua
+++ b/worldeditadditions/init.lua
@@ -15,6 +15,7 @@ dofile(worldeditadditions.modpath.."/utils/node_identification.lua")
 dofile(worldeditadditions.modpath.."/utils/tables.lua")
 dofile(worldeditadditions.modpath.."/utils/terrain.lua")
 dofile(worldeditadditions.modpath.."/utils/raycast_adv.lua") -- For the farwand
+dofile(worldeditadditions.modpath.."/utils/selector_helps.lua")
 
 dofile(worldeditadditions.modpath.."/lib/compat/saplingnames.lua")
 

--- a/worldeditadditions/utils/selector_helps.lua
+++ b/worldeditadditions/utils/selector_helps.lua
@@ -1,6 +1,6 @@
 function worldeditadditions.player_axis2d(name)
   -- minetest.get_player_by_name("singleplayer"):
-	local dir = math.floor(minetest.get_player_by_name(name):get_look_horizontal() / math.pi * 2 + 0.5) % 3
+	local dir = math.floor(minetest.get_player_by_name(name):get_look_horizontal() / math.pi * 2 + 0.5) % 4
 	local crdnl = { {1,"z"},{-1,"x"},{-1,"z"},{1,"x"} }
   return crdnl[dir+1]
 end

--- a/worldeditadditions/utils/selector_helps.lua
+++ b/worldeditadditions/utils/selector_helps.lua
@@ -1,0 +1,9 @@
+function worldeditadditions.player_axis2d(name)
+  -- minetest.get_player_by_name("singleplayer"):
+	local dir = math.floor(minetest.get_player_by_name(name):get_look_horizontal() / math.pi * 2 + 0.5) % 3
+	local crdnl = { {1,"z"},{-1,"x"},{-1,"z"},{1,"x"} }
+  return crdnl[dir+1]
+end
+
+-- Tests
+-- /lua print(unpack(worldeditadditions.player_axis2d(myname)))

--- a/worldeditadditions_commands/commands/extra/basename.lua
+++ b/worldeditadditions_commands/commands/extra/basename.lua
@@ -8,7 +8,9 @@ worldedit.register_command("basename", {
 	description = "Returns the base name of nodes that use a given alias.",
 	privs = {worldedit = true},
   parse = function(params_text)
-    params_text = params_text or "air"
+    if params_text == "" or not params_text then
+    	return false, "Node not specified."
+    end
     return true, params_text
 	end,
 	func = function(name, params_text)

--- a/worldeditadditions_commands/commands/extra/basename.lua
+++ b/worldeditadditions_commands/commands/extra/basename.lua
@@ -1,0 +1,18 @@
+-- ██████   █████  ███████ ███████ ███    ██  █████  ███    ███ ███████
+-- ██   ██ ██   ██ ██      ██      ████   ██ ██   ██ ████  ████ ██
+-- ██████  ███████ ███████ █████   ██ ██  ██ ███████ ██ ████ ██ █████
+-- ██   ██ ██   ██      ██ ██      ██  ██ ██ ██   ██ ██  ██  ██ ██
+-- ██████  ██   ██ ███████ ███████ ██   ████ ██   ██ ██      ██ ███████
+worldedit.register_command("basename", {
+	params = "<nodealias>",
+	description = "Returns the base name of nodes that use a given alias.",
+	privs = {worldedit = true},
+  parse = function(params_text)
+    params_text = params_text or "air"
+    return true, params_text
+	end,
+	func = function(name, params_text)
+    if name == nil then return end
+    worldedit.player_notify(name, worldedit.normalize_nodename(params_text) or 'Error 404: "'..params_text..'" not found!')
+	end
+})

--- a/worldeditadditions_commands/commands/extra/saplingaliases.lua
+++ b/worldeditadditions_commands/commands/extra/saplingaliases.lua
@@ -1,3 +1,8 @@
+-- ███████  █████  ██████  ██      ██ ███    ██  ██████   █████  ██      ██  █████  ███████ ███████ ███████
+-- ██      ██   ██ ██   ██ ██      ██ ████   ██ ██       ██   ██ ██      ██ ██   ██ ██      ██      ██
+-- ███████ ███████ ██████  ██      ██ ██ ██  ██ ██   ███ ███████ ██      ██ ███████ ███████ █████   ███████
+--      ██ ██   ██ ██      ██      ██ ██  ██ ██ ██    ██ ██   ██ ██      ██ ██   ██      ██ ██           ██
+-- ███████ ██   ██ ██      ███████ ██ ██   ████  ██████  ██   ██ ███████ ██ ██   ██ ███████ ███████ ███████
 minetest.register_chatcommand("/saplingaliases", {
 	params = "[aliases|all_saplings]",
 	description = "Lists all the currently registered sapling aliases (default). A single argument is taken as the mode of operation. Current modes: aliases (default; as described previously), all_saplings (lists all node names with the group \"sapling\")",
@@ -7,9 +12,9 @@ minetest.register_chatcommand("/saplingaliases", {
 		if params_text == "" or not params_text then
 			params_text = "aliases"
 		end
-		
+
 		local msg = {}
-		
+
 		if params_text == "aliases" then
 			table.insert(msg, "Currently registered aliases:\n")
 			local aliases = worldeditadditions.get_all_sapling_aliases()

--- a/worldeditadditions_commands/commands/forest.lua
+++ b/worldeditadditions_commands/commands/forest.lua
@@ -1,8 +1,9 @@
---  ██████  ██    ██ ███████ ██████  ██       █████  ██    ██
--- ██    ██ ██    ██ ██      ██   ██ ██      ██   ██  ██  ██
--- ██    ██ ██    ██ █████   ██████  ██      ███████   ████
--- ██    ██  ██  ██  ██      ██   ██ ██      ██   ██    ██
---  ██████    ████   ███████ ██   ██ ███████ ██   ██    ██
+-- ███████  ██████  ██████  ███████ ███████ ████████
+-- ██      ██    ██ ██   ██ ██      ██         ██
+-- █████   ██    ██ ██████  █████   ███████    ██
+-- ██      ██    ██ ██   ██ ██           ██    ██
+-- ██       ██████  ██   ██ ███████ ███████    ██
+
 worldedit.register_command("forest", {
 	params = "[<density>] <sapling_a> [<chance_a>] <sapling_b> [<chance_b>] [<sapling_N> [<chance_N>]] ...",
 	description = "Plants and grows trees in the defined region according to the given list of sapling names and chances and density factor. The density controls the relative density of the resulting forest, and defaults to 1 (floating-point numbers allowed). Higher chance numbers result in a lower relative chance with respect to other saplings in the list. Saplings that fail to grow are subsequently removed (this will affect pre-existing saplings too).",
@@ -15,7 +16,7 @@ worldedit.register_command("forest", {
 			density = tonumber(match_start)
 			params_text = params_text:sub(#match_start + 1) -- everything starts at 1 in Lua :-/
 		end
-		
+
 		local success, sapling_list = worldeditadditions.parse_weighted_nodes(
 			worldeditadditions.split(params_text, "%s+", false),
 			false,
@@ -42,11 +43,11 @@ worldedit.register_command("forest", {
 		)
 		if not success then return success, stats end
 		local time_taken = worldeditadditions.human_time(worldeditadditions.get_ms_time() - start_time)
-		
+
 		local distribution_display = worldeditadditions.make_ascii_table(
 			worldeditadditions.node_distribution_to_list(stats.placed, stats.successes)
 		)
-		
+
 		minetest.log("action", name.." used //forest at "..worldeditadditions.vector.tostring(worldedit.pos1[name]).." - "..worldeditadditions.vector.tostring(worldedit.pos2[name])..", "..stats.successes.." trees placed, averaging "..stats.attempts_avg.." growth attempts / tree and "..stats.failures.." failed attempts in "..time_taken)
 		return true, distribution_display.."\n=========================\n"..stats.successes.." trees placed, averaging "..stats.attempts_avg.." growth attempts / tree and "..stats.failures.." failed attempts in "..time_taken
 	end

--- a/worldeditadditions_commands/commands/selectors/srect.lua
+++ b/worldeditadditions_commands/commands/selectors/srect.lua
@@ -1,0 +1,51 @@
+-- ███████ ██████  ███████  ██████ ████████
+-- ██      ██   ██ ██      ██         ██
+-- ███████ ██████  █████   ██         ██
+--      ██ ██   ██ ██      ██         ██
+-- ███████ ██   ██ ███████  ██████    ██
+-- lua parse_params_srect("10")
+-- local
+function parse_params_srect(params_text)
+  local find, _, sn1, ax1, sn2, ax2, len = params_text:find("([+-]?)([xyz]?)%s*([+-]?)([xyz]?)%s*(%d*)")
+
+  -- If ax1 is nil set to player facing dir
+  if ax1 == "" then ax1 = "get"
+  else ax1 = {tonumber(sn1..1),string.lower(ax1)}
+	end
+  -- If ax2 is nil set to +y
+  if ax2 == "" then ax2 = "y" end
+  ax2 = {tonumber(sn2..1),string.lower(ax2)}
+
+  len = tonumber(len)
+  if len == nil then
+    return false, "No length specified."
+  end
+
+  return true, ax1, ax2, len
+end
+worldedit.register_command("srect", {
+	params = "[<axis1> [<axis2>]] <length>",
+	description = "Set WorldEdit region position 2 at a set distance along 2 axes.",
+	privs = {worldedit=true},
+  require_pos = 1,
+  parse = function(params_text)
+		local values = {parse_params_srect(params_text)}
+		return unpack(values)
+	end,
+	func = function(name, axis1, axis2, len)
+    if axis1 == "get" then axis1 = worldeditadditions.player_axis2d(name) end
+
+		local pos1 = worldedit.pos1[name]
+    local p2 = {["x"] = pos1.x,["y"] = pos1.y,["z"] = pos1.z}
+
+    p2[axis1[2]] = p2[axis1[2]] + tonumber(len) * axis1[1]
+    p2[axis2[2]] = p2[axis2[2]] + tonumber(len) * axis2[1]
+
+		worldedit.pos2[name] = p2
+		worldedit.mark_pos2(name)
+		worldedit.player_notify(name, "position 2 set to " .. minetest.pos_to_string(p2))
+	end,
+})
+
+-- Tests
+-- params_text = "-x z 13"

--- a/worldeditadditions_commands/init.lua
+++ b/worldeditadditions_commands/init.lua
@@ -35,12 +35,18 @@ dofile(we_c.modpath.."/commands/hollow.lua")
 dofile(we_c.modpath.."/commands/scale.lua")
 
 dofile(we_c.modpath.."/commands/count.lua")
-dofile(we_c.modpath.."/commands/saplingaliases.lua")
 
 dofile(we_c.modpath.."/commands/meta/multi.lua")
 dofile(we_c.modpath.."/commands/meta/many.lua")
 dofile(we_c.modpath.."/commands/meta/subdivide.lua")
 dofile(we_c.modpath.."/commands/meta/ellipsoidapply.lua")
+
+-- dofile(we_c.modpath.."/commands/selectors/scol.lua")
+dofile(we_c.modpath.."/commands/selectors/srect.lua")
+-- dofile(we_c.modpath.."/commands/selectors/scube.lua")
+
+dofile(we_c.modpath.."/commands/extra/saplingaliases.lua")
+dofile(we_c.modpath.."/commands/extra/basename.lua")
 
 -- Don't registry the //bonemeal command if the bonemeal mod isn't present
 if minetest.get_modpath("bonemeal") then


### PR DESCRIPTION
Also moved saplingaliases to `worldeditadditions_commands\extra` and corrected the block text in forest.lua to say "Forest" and not "Overlay".

## `//srect`
### Syntax: 
`//srect [<axis1> [<axis2>]] <length>`
### Defaults: 
- axis1: player horizontal look direction (+-x or +-z)
- axis2: +y
### Demo commands:
```
//srect 5
//screct -x z 5
```
## `//basename`
### Syntax:
`//basename <nodealias>`
### Demo Commands:
```
//basename stone
```