### PR TITLE
Fix bonemeal alias registration by conditionally registering flora alias only when bonemeal mod is present

### DIFF
--- a/worldeditadditions_commands/aliases.lua
+++ b/worldeditadditions_commands/aliases.lua
@@ -7,7 +7,11 @@ wea_c.register_alias("conv", "convolve")
 wea_c.register_alias("naturalise", "layers")
 wea_c.register_alias("naturalize", "layers")
 
-wea_c.register_alias("flora", "bonemeal")
+-- Only register the flora alias if the bonemeal command is available
+-- This depends on the bonemeal mod being present
+if minetest.global_exists("bonemeal") then
+	wea_c.register_alias("flora", "bonemeal")
+end
 
 -- Measure Tools
 wea_c.register_alias("mcount", "count")


### PR DESCRIPTION
WorldEditAdditions is trying to register an alias from `bonemeal` to `flora`, but the `bonemeal` command doesn't exist (because the bonemeal mod isn't detected). However, the alias registration is still proceeding and this is likely creating a command definition with a `nil` source.